### PR TITLE
The right method for getting the reply-to email

### DIFF
--- a/Lib/Network/Email/SendgridTransport.php
+++ b/Lib/Network/Email/SendgridTransport.php
@@ -50,6 +50,7 @@ class SendgridTransport extends AbstractTransport {
 
         $this->_headers = $this->_cakeEmail->getHeaders();
         $this->_recipients = $email->to();
+        $this->_replyTo = $email->replyTo();
 
         return $this->_sendPart();
 
@@ -83,8 +84,8 @@ class SendgridTransport extends AbstractTransport {
             'text'      => $this->_cakeEmail->message('text'),
             'from'      => $this->_config['from'],
             'fromname'  => $this->_config['fromName'],
+            'replyto'   => array_keys($this->_replyTo)[0],
         );
-        if (!empty($this->_config['replyTo'])) $params['replyto'] = $this->_config['replyTo'];
 
         $attachments = $this->_cakeEmail->attachments();
         if (!empty($attachments)) {


### PR DESCRIPTION
This is the right method for extracting the reply-to email address.
`$email->replyTo();` returns an array with emails, each element has the email address as key and the value is the name. My code extracts the key from the first item in that array.