### PR TITLE
Update for the new api url

### DIFF
--- a/Lib/Network/Email/SendgridTransport.php
+++ b/Lib/Network/Email/SendgridTransport.php
@@ -120,7 +120,7 @@ class SendgridTransport extends AbstractTransport {
     }
 
     private function _exec($params) {
-        $request =  'http://sendgrid.com/api/mail.send.json';
+        $request =  'https://api.sendgrid.com/api/mail.send.json';
         $email = new HttpSocket();
         $response = $email->post($request, $params);
         return $response->body;


### PR DESCRIPTION
Sendgrid just announced that on 9 feb `http://sendgrid.com/api/` will not work anymore, it will be replaced with `https://api.sendgrid.com/api/`
https://sendgrid.com/docs/API_Reference/Web_API/using_the_web_api.html