### PR TITLE
Configure HttpSocket to ignore hostname match errors

### DIFF
--- a/Lib/Network/Email/SendgridTransport.php
+++ b/Lib/Network/Email/SendgridTransport.php
@@ -122,8 +122,7 @@ class SendgridTransport extends AbstractTransport {
     private function _exec($params) {
         $request =  'https://api.sendgrid.com/api/mail.send.json';
         $email = new HttpSocket(array(
-          'ssl_verify_host' => false,
-          'ssl_verify_peer' => false
+          'ssl_verify_host' => false
         ));
         $response = $email->post($request, $params);
         return $response->body;

--- a/Lib/Network/Email/SendgridTransport.php
+++ b/Lib/Network/Email/SendgridTransport.php
@@ -121,7 +121,10 @@ class SendgridTransport extends AbstractTransport {
 
     private function _exec($params) {
         $request =  'https://api.sendgrid.com/api/mail.send.json';
-        $email = new HttpSocket();
+        $email = new HttpSocket(array(
+          'ssl_verify_host' => false,
+          'ssl_verify_peer' => false
+        ));
         $response = $email->post($request, $params);
         return $response->body;
     }


### PR DESCRIPTION
Unless HttpSocket is configured to ignore hostname match errors, the following error is returned when using the new HTTPS endpoint

```javascript
exception 'SocketException' with message 'stream_socket_client(): Peer certificate CN=`*.api.sendgrid.com' did not match expected CN=`api.sendgrid.com'
```

This PR adds the missing configuration parameter.