### PR TITLE
Fix syntax error in some PHP versions

### DIFF
--- a/Lib/Network/Email/SendgridTransport.php
+++ b/Lib/Network/Email/SendgridTransport.php
@@ -74,6 +74,7 @@ class SendgridTransport extends AbstractTransport {
             }
         }
 
+        $replyTos = array_keys($this->_replyTo);
         $params = array(
             'api_user'  => $this->_config['username'],
             'api_key'   => $this->_config['password'],
@@ -84,7 +85,7 @@ class SendgridTransport extends AbstractTransport {
             'text'      => $this->_cakeEmail->message('text'),
             'from'      => $this->_config['from'],
             'fromname'  => $this->_config['fromName'],
-            'replyto'   => array_keys($this->_replyTo)[0],
+            'replyto'   => $replyTos[0],
         );
 
         $attachments = $this->_cakeEmail->attachments();


### PR DESCRIPTION
The original line was `array_keys($this->_replyTo)[0]` but this syntax (an expression in parentheses followed by square brackets) was causing a syntax error in some older PHP versions (specifically, PHP 5.3.3  in my case)
